### PR TITLE
Feature to disable add files button

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Launcher props:
 | newMessagesCount | number | no | The number of new messages. If greater than 0, this number will be displayed in a badge on the launcher. Defaults to `0`. |
 | onFilesSelected  | function([fileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList)) | no | Called after file has been selected from dialogue in chat window. |
 | onMessageWasSent | function([message](#message-objects)) | yes | Called when a message is sent, with a message object as an argument. |
-| showEmoji        | boolean | no | Whether or not to show the emoji button in the input bar. Defaults to `true`.
+| showEmoji        | boolean | no | Whether or not to show the emoji button in the input bar. Defaults to `true`. |
+| showFilePicker   | boolean | no | Whether or not to show the file picker button in the input bar. Defaults to `true`.
 
 
 ### Message Objects

--- a/src/components/ChatWindow.js
+++ b/src/components/ChatWindow.js
@@ -39,6 +39,7 @@ class ChatWindow extends Component {
           onSubmit={this.onUserInputSubmit.bind(this)}
           onFilesSelected={this.onFilesSelected.bind(this)}
           showEmoji={this.props.showEmoji}
+          showFilePicker={this.props.showFilePicker}
         />
       </div>
     );
@@ -51,7 +52,8 @@ ChatWindow.propTypes = {
   onClose: PropTypes.func.isRequired,
   onFilesSelected: PropTypes.func,
   onUserInputSubmit: PropTypes.func.isRequired,
-  showEmoji: PropTypes.bool
+  showEmoji: PropTypes.bool,
+  showFilePicker: PropTypes.bool
 };
 
 export default ChatWindow;

--- a/src/components/Launcher.js
+++ b/src/components/Launcher.js
@@ -60,6 +60,7 @@ class Launcher extends Component {
           isOpen={isOpen}
           onClose={this.handleClick.bind(this)}
           showEmoji={this.props.showEmoji}
+          showFilePicker={this.props.showFilePicker}
         />
       </div>
     );
@@ -84,11 +85,13 @@ Launcher.propTypes = {
   messageList: PropTypes.arrayOf(PropTypes.object),
   mute: PropTypes.bool,
   showEmoji: PropTypes.bool,
+  showFilePicker: PropTypes.bool
 };
 
 Launcher.defaultProps = {
   newMessagesCount: 0,
-  showEmoji: true
+  showEmoji: true,
+  showFilePicker: true
 };
 
 export default Launcher;

--- a/src/components/UserInput.js
+++ b/src/components/UserInput.js
@@ -20,7 +20,7 @@ class UserInput extends Component {
   }
 
   componentDidMount() {
-    this.emojiPickerButton = document.querySelector('#sc-emoji-picker-button'); 
+    this.emojiPickerButton = document.querySelector('#sc-emoji-picker-button');
   }
 
   handleKeyDown(event) {
@@ -111,19 +111,20 @@ class UserInput extends Component {
           <SendIcon onClick={this._submitText.bind(this)} />
         </div>
       );
+    } else if (this.props.showFilePicker) {
+      return (
+        <div className="sc-user-input--button">
+          <FileIcon onClick={this._showFilePicker.bind(this)} />
+          <input
+            type="file"
+            name="files[]"
+            multiple
+            ref={(e) => { this._fileUploadButton = e; }}
+            onChange={this._onFilesSelected.bind(this)}
+          />
+        </div>
+      );
     }
-    return (
-      <div className="sc-user-input--button">
-        <FileIcon onClick={this._showFilePicker.bind(this)} />
-        <input
-          type="file"
-          name="files[]"
-          multiple
-          ref={(e) => { this._fileUploadButton = e; }}
-          onChange={this._onFilesSelected.bind(this)}
-        />
-      </div>
-    );
   }
 
   render() {
@@ -162,7 +163,8 @@ class UserInput extends Component {
 UserInput.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onFilesSelected: PropTypes.func.isRequired,
-  showEmoji: PropTypes.bool
+  showEmoji: PropTypes.bool,
+  showFilePicker: PropTypes.bool
 };
 
 export default UserInput;


### PR DESCRIPTION
## Description
Added a prop that decides whether or not to show the add files button in the input bar.

## Checklist
* [x] Additions/changes follow the current code structure
* [x] All changes are related to a single topic
* [x] Demo tested (`npm start`) to ensure it still functions as expected, and/or
* [ ] New features are demonstrated to the demo (leave checkbox blank if not applicable)
* [x] Readme/docs are updated
* [x] `npm run lint` passes (`npm run lint -- --fix` will autofix where possible)
